### PR TITLE
Changed install version to 2.x-dev from 2.x

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ This is a generic Drupal site auditing and optional remediation tool.
 You can install Drutiny into your project with [composer](https://getcomposer.org). Drutiny is a require-dev type dependency.
 
 ```
-composer require --dev drutiny/drutiny 2.x
+composer require --dev drutiny/drutiny 2.x-dev
 ```
 
 Alternately, Drutiny can be built as a standalone tool:


### PR DESCRIPTION
I got error while trying to install by using 

`composer require --dev drutiny/drutiny 2.x` 

```Problem 1
    - The requested package drutiny/drutiny 2.x is satisfiable by drutiny/drutiny[2.0.0-alpha1, 2.x-dev] but these conflict with your requirements or minimum-stability.
```

Changing version to `2.x-dev` fixed above issue.